### PR TITLE
TREQ-21: Throw FileNotFoundException when resource is not found

### DIFF
--- a/tiles-request-api/pom.xml
+++ b/tiles-request-api/pom.xml
@@ -31,10 +31,21 @@ under the License.
     <version>1.0.7-SNAPSHOT</version>
     <name>Tiles request - API</name>
     <description>API for the Tiles Request framework.</description>
+
+    <properties>
+        <osgi.version>6.0.0</osgi.version>
+        <exam.version>4.11.0</exam.version>
+        <url.version>2.5.2</url.version>
+        <felix.version>5.6.4</felix.version>
+        <slf4j-api.version>1.7.25</slf4j-api.version>
+        <logback.version>1.2.2</logback.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -44,6 +55,54 @@ under the License.
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymockclassextension</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-native</artifactId>
+            <version>${exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-junit4</artifactId>
+            <version>${exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-link-mvn</artifactId>
+            <version>${exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-aether</artifactId>
+            <version>${url.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <version>${felix.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${osgi.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tiles-request-api/src/test/java/org/apache/tiles/request/locale/TestApplicationResource.java
+++ b/tiles-request-api/src/test/java/org/apache/tiles/request/locale/TestApplicationResource.java
@@ -1,0 +1,52 @@
+/*
+ * $Id$
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tiles.request.locale;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Locale;
+
+/**
+ * Test implementation of {@link URLApplicationResource}
+ */
+public class TestApplicationResource extends URLApplicationResource {
+
+    public TestApplicationResource(String localePath, URL url) throws URISyntaxException {
+        super(localePath, url);
+    }
+
+    public TestApplicationResource(String path, Locale locale, URL url) throws MalformedURLException, URISyntaxException {
+        super(path, locale, url);
+    }
+
+    @Override
+    protected URL getURL() {
+        return super.getURL();
+    }
+
+    @Override
+    protected File getFile() {
+        return super.getFile();
+    }
+}

--- a/tiles-request-api/src/test/java/org/apache/tiles/request/locale/URLApplicationResourceTest.java
+++ b/tiles-request-api/src/test/java/org/apache/tiles/request/locale/URLApplicationResourceTest.java
@@ -20,20 +20,18 @@
  */
 
 package org.apache.tiles.request.locale;
+import org.junit.Test;
+
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
 
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Tests URLApplicationResource.
@@ -41,26 +39,6 @@ import org.junit.Test;
  * @version $Rev$ $Date$
  */
 public class URLApplicationResourceTest {
-
-    private class TestApplicationResource extends URLApplicationResource {
-        public TestApplicationResource(String localePath, URL url) throws URISyntaxException {
-            super(localePath, url);
-        }
-
-        public TestApplicationResource(String path, Locale locale, URL url) throws MalformedURLException, URISyntaxException {
-            super(path, locale, url);
-        }
-
-        @Override
-        protected URL getURL(){
-            return super.getURL();
-        }
-
-        @Override
-        protected File getFile(){
-            return super.getFile();
-        }
-    };
 
     /**
      * Test getLocalePath(String path, Locale locale).
@@ -200,5 +178,16 @@ public class URLApplicationResourceTest {
     	InputStream is = resource.getInputStream();
     	assertNotNull(is);
     	is.close();
+    }
+
+    @Test
+    public void testProtocolNotFileAndNoManifestFound() throws IOException {
+        URL url = new URL("http://--$_foo.org/bar.txt");
+        URLApplicationResource resource = new URLApplicationResource("org/apache/tiles/request/test/locale/resource.txt", url);
+        try {
+            resource.getInputStream();
+        } catch (IOException e) {
+            assertFalse(e instanceof FileNotFoundException);
+        }
     }
 }

--- a/tiles-request-api/src/test/java/org/apache/tiles/request/osgi/URLBundleApplicationResourceTest.java
+++ b/tiles-request-api/src/test/java/org/apache/tiles/request/osgi/URLBundleApplicationResourceTest.java
@@ -1,0 +1,81 @@
+/*
+ * $Id$
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.tiles.request.osgi;
+
+import org.apache.tiles.request.locale.TestApplicationResource;
+import org.apache.tiles.request.locale.URLApplicationResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.Assert.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
+/**
+ * Tests OSGi behaviour of URLApplicationResource.
+ *
+ * @version $Rev$ $Date$
+ */
+@RunWith(PaxExam.class)
+public class URLBundleApplicationResourceTest {
+
+    @Configuration
+    public Option[] configuration() throws IOException {
+        return new Option[]{
+                junitBundles(),
+                frameworkProperty("org.osgi.framework.bundle.parent").value("app"),
+                bootDelegationPackage("org.apache.tiles.request.locale"),
+        };
+    }
+
+    @Test
+    public void testGetLastModified() throws Exception {
+        URL url = new URL(getClass().getResource("/org/apache/tiles/request/test/locale/resource.txt"),"notExisting");
+        TestApplicationResource resource = new TestApplicationResource("/my test/path_fr.html", url);
+
+        try {
+            resource.getLastModified();
+            fail("Exception expected");
+        } catch (FileNotFoundException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGetInputStream() throws IOException {
+        URL url = new URL(getClass().getResource("/org/apache/tiles/request/test/locale/resource.txt"),"notExisting");
+        URLApplicationResource resource = new URLApplicationResource("org/apache/tiles/request/test/locale/resource.txt", url);
+
+        try {
+            resource.getInputStream();
+            fail("Exception expected");
+        } catch (FileNotFoundException e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
- Check on construction time whether the URL points into a bundle
- Always throw a FileNotFoundException when the URL points into a bundle
and url.openConnection throws an IOException
- Added OSGi tests